### PR TITLE
Added explicit int64 for lifetime

### DIFF
--- a/natpmp.go
+++ b/natpmp.go
@@ -75,7 +75,7 @@ type AddPortMappingResult struct {
 
 // Add (or delete) a port mapping. To delete a mapping, set the requestedExternalPort and lifetime to 0.
 // Note that this call can take up to 128 seconds to return.
-func (n *Client) AddPortMapping(protocol string, internalPort, requestedExternalPort int, lifetime int) (result *AddPortMappingResult, err error) {
+func (n *Client) AddPortMapping(protocol string, internalPort, requestedExternalPort int, lifetime int64) (result *AddPortMappingResult, err error) {
 	var opcode byte
 	if protocol == "udp" {
 		opcode = 1

--- a/natpmp_test.go
+++ b/natpmp_test.go
@@ -100,7 +100,7 @@ type addPortMappingRecord struct {
 	protocol              string
 	internalPort          int
 	requestedExternalPort int
-	lifetime              int
+	lifetime              int64
 	result                *AddPortMappingResult
 	err                   error
 	cr                    callRecord


### PR DESCRIPTION
I have found that `go-nat-pmp` won't compile on x86 platforms because of `lifetime` being int32 in 32-bit platforms.
So any time you would try to use `time.Duration` more than 1 second - you would get this:
```
 cannot convert time.Duration(60 * time.Second) (constant 60000000000 of type time.Duration) to type int
```

We can explicitly set `lifetime` as `int64` instead.