### PR TITLE
Support specifying local IP address

### DIFF
--- a/natpmp.go
+++ b/natpmp.go
@@ -33,13 +33,25 @@ type Client struct {
 // Create a NAT-PMP client for the NAT-PMP server at the gateway.
 // Uses default timeout which is around 128 seconds.
 func NewClient(gateway net.IP) (nat *Client) {
-	return &Client{&network{gateway}, 0}
+	return &Client{&network{gateway, nil}, 0}
+}
+
+// Create a NAT-PMP client for the NAT-PMP server at the gateway with the specified local address.
+// Uses default timeout which is around 128 seconds.
+func NewClientWithLocal(gateway net.IP, local net.IP) (nat *Client) {
+	return &Client{&network{gateway, local}, 0}
 }
 
 // Create a NAT-PMP client for the NAT-PMP server at the gateway, with a timeout.
 // Timeout defines the total amount of time we will keep retrying before giving up.
 func NewClientWithTimeout(gateway net.IP, timeout time.Duration) (nat *Client) {
-	return &Client{&network{gateway}, timeout}
+	return &Client{&network{gateway, nil}, timeout}
+}
+
+// Create a NAT-PMP client for the NAT-PMP server at the gateway, with a timeout.
+// Timeout defines the total amount of time we will keep retrying before giving up.
+func NewClientWithLocalandTimeout(gateway net.IP, local net.IP, timeout time.Duration) (nat *Client) {
+	return &Client{&network{gateway, local}, timeout}
 }
 
 // Results of the NAT-PMP GetExternalAddress operation.

--- a/network.go
+++ b/network.go
@@ -13,13 +13,19 @@ const nAT_INITIAL_MS = 250
 // A caller that implements the NAT-PMP RPC protocol.
 type network struct {
 	gateway net.IP
+	local   net.IP
 }
 
 func (n *network) call(msg []byte, timeout time.Duration) (result []byte, err error) {
-	var server net.UDPAddr
+	var server, local net.UDPAddr
+	var localp *net.UDPAddr = nil
 	server.IP = n.gateway
 	server.Port = nAT_PMP_PORT
-	conn, err := net.DialUDP("udp", nil, &server)
+	if n.local != nil {
+		local.IP = n.local
+		localp = &local
+	}
+	conn, err := net.DialUDP("udp", localp, &server)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This adds a `local` member to the `network` struct and a new `NewClientWithLocal` interface. The existing interfaces are unchanged although the size of the `Client` struct obviously is impacted.  I found this necessary for my usage of transmission-protonvpn-nat-pmp where I had my Wireguard interface using a separate routing table to reach the gateway address.